### PR TITLE
Fix failing tests and add systemd example

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,10 @@ services:
 ## Linux service example
 
 On Linux you can run `mcp-proxy` as a `systemd` service. This allows it to start
-automatically and run under a dedicated sub-user. The example below exposes the
-proxy on `0.0.0.0:8096` and runs the server as the `mcpproxy` user.
+automatically and run under a dedicated sub-user. A ready to use example unit
+file is included as `mcp-proxy.service.example` in the project root. The snippet
+below exposes the proxy on `0.0.0.0:8096` and runs the server as the
+`mcpproxy` user.
 
 1. Create the service user (once):
 

--- a/mcp-proxy.service.example
+++ b/mcp-proxy.service.example
@@ -1,0 +1,14 @@
+[Unit]
+Description=MCP proxy service
+After=network.target
+
+[Service]
+Type=simple
+User=agi-core
+Group=agi-core
+ExecStart=/srv/agi-connectors/proxy/venv/bin/mcp-proxy --port=18500 --host 127.0.0.2 --oauth --named-server-config /srv/agi-connectors/proxy/config.json
+Restart=on-failure
+WorkingDirectory=/srv/agi-connectors/proxy/
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- fix test fixtures to avoid name clashes
- adjust completion fixture to ignore unused context
- add `mcp-proxy.service.example` systemd unit file
- mention the example service file in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875a36dfca083298a1fe1fffb588d95